### PR TITLE
Update getCurrentActivity in GoogleAuthModule.kt

### DIFF
--- a/android/src/main/java/com/googleauth/GoogleAuthModule.kt
+++ b/android/src/main/java/com/googleauth/GoogleAuthModule.kt
@@ -300,7 +300,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
     }
 
     // No cached tokens, try silent sign-in
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       promise.reject("NO_ACTIVITY", "No current activity available")
       return
@@ -347,7 +347,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
       return
     }
 
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       promise.reject("NO_ACTIVITY", "No current activity available")
       return
@@ -438,7 +438,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
       }
       
       if (!isAvailable && showErrorDialog == true) {
-        currentActivity?.let { activity ->
+        reactApplicationContext.currentActivity?.let { activity ->
           if (googleApiAvailability.isUserResolvableError(resultCode)) {
             googleApiAvailability.getErrorDialog(activity, resultCode, 9000)?.show()
           }
@@ -454,7 +454,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
   // MARK: - Helper Methods
   
   private fun getValidActivity(): Activity? {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     return if (activity != null && !activity.isFinishing && !activity.isDestroyed) {
       activity
     } else {


### PR DESCRIPTION
This document explains the full evolution of how the current `Activity` is accessed in React Native Android native modules, and why this change was required for modern React Native versions.

---

## 1. Legacy Behavior: `currentActivity` (Pre–RN 0.60)

In older React Native versions, native modules (Java-based) could directly access the current Activity via an implicitly exposed field:

```java
currentActivity
```

When these modules were later converted to Kotlin, some codebases continued to rely on Kotlin’s lenient property access, treating:

```kotlin
currentActivity
```

as a valid reference, even though no explicit property existed.

This worked due to:
- Java interoperability
- Older Kotlin compiler permissiveness
- Older Android Gradle Plugin behavior

---

## 2. Official API: `getCurrentActivity()` (RN 0.60 – RN 0.79)

React Native standardized Activity access through `ReactContextBaseJavaModule`:

```kotlin
fun getCurrentActivity(): Activity?
```

Correct usage required invoking the function explicitly:

```kotlin
val activity = getCurrentActivity()
```

However, many libraries incorrectly used:

```kotlin
val activity = getCurrentActivity
```

This compiled in older toolchains but was **technically invalid Kotlin**.

---

## 3. Breakage with Modern Toolchains (Kotlin 1.9+ / AGP 8+)

With newer versions of:
- Kotlin (1.9 / 2.x)
- Android Gradle Plugin (8.x)

The compiler became strict and no longer allowed treating function references as properties.

This resulted in build errors such as:

```
Function invocation 'getCurrentActivity()' expected.
```

---

## 4. Deprecation in React Native 0.80

As of **React Native 0.80**, `getCurrentActivity()` itself is deprecated:

```
'fun getCurrentActivity(): Activity?' is deprecated.
Use reactApplicationContext.currentActivity instead.
```

The recommended and future-proof API is now:

```kotlin
reactApplicationContext.currentActivity
```

This property:
- Is nullable (`Activity?`)
- Is lifecycle-aware
- Works with the New Architecture (TurboModules)

---

## 5. Final, Recommended Implementation

```kotlin
val activity = reactApplicationContext.currentActivity
    ?: throw IllegalStateException("Current activity is null")
```

This approach:
- Avoids deprecated APIs
- Compiles on modern Kotlin/AGP
- Is compatible with React Native 0.80+
- Does not change runtime behavior

---

## Summary Table

| Era | API | Status |
|----|----|----|
| Legacy RN | `currentActivity` | ❌ Removed |
| RN 0.60–0.79 | `getCurrentActivity()` | ⚠️ Deprecated |
| RN 0.80+ | `reactApplicationContext.currentActivity` | ✅ Recommended |

---

## Conclusion

This change sequence explains why older libraries break on modern React Native setups and why updating to `reactApplicationContext.currentActivity` is required to maintain compatibility going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for activity reference handling in authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->