### PR TITLE
feat(google-auth): add credentialManagerMode for customizable sign-in behaviour

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - FBLazyVector (0.81.0)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAuth (2.1.0):
+  - GoogleAuth (1.2.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2598,7 +2598,7 @@ SPEC CHECKSUMS:
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  GoogleAuth: d45f30ae4d49edbaf5e48d56586e164b925bf004
+  GoogleAuth: eec941506f196ee17b5e9a74a3b83e720d599232
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
@@ -2665,7 +2665,7 @@ SPEC CHECKSUMS:
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
   React-utils: 068cec677032ba78ca0700f2dcbe6d08a0939647
   ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
-  ReactCodegen: 5695f203204e30acbf7d6c06dbb8d0f391e52133
+  ReactCodegen: a55799cae416c387aeaae3aabc1bc0289ac19cee
   ReactCommon: 116d6ee71679243698620d8cd9a9042541e44aa6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782

--- a/src/NativeGoogleAuth.ts
+++ b/src/NativeGoogleAuth.ts
@@ -118,6 +118,16 @@ export interface ConfigureParams {
    * @platform iOS
    */
   forceAccountPicker?: boolean;
+
+  /**
+   * Android Credential Manager behavior mode
+   * - 'silent': Only show existing authorized accounts, no UI interaction
+   * - 'interactive': Always display the Google account picker UI
+   * - 'auto': Try silent sign-in first, fallback to interactive if needed (default)
+   * Default: 'auto'
+   * @platform Android
+   */
+  credentialManagerMode?: 'silent' | 'interactive' | 'auto';
 }
 
 export interface User {


### PR DESCRIPTION
resolves: https://github.com/sbaiahmed1/react-native-google-auth/issues/16

- Introduced `credentialManagerMode` to control sign-in on Android
- Updated Android implementation to handle the new parameter with validation
- Documented the `credentialManagerMode` option in the TypeScript interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `credentialManagerMode` configuration option to control Android sign-in flow behavior.
  * Three modes available: silent (silent attempts only), interactive (always interactive), and auto (silent first with interactive fallback).
  * Defaults to "auto" mode, preserving existing sign-in behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->