### PR TITLE
Fix/base64 encoding

### DIFF
--- a/android/src/main/java/com/googleauth/GoogleAuthModule.kt
+++ b/android/src/main/java/com/googleauth/GoogleAuthModule.kt
@@ -1,7 +1,6 @@
 package com.googleauth
 
 import android.app.Activity
-import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.lifecycle.Lifecycle
@@ -32,8 +31,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Date
-import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 import java.util.Base64
 

--- a/android/src/main/java/com/googleauth/GoogleAuthModule.kt
+++ b/android/src/main/java/com/googleauth/GoogleAuthModule.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import java.util.Base64
+import android.util.Base64
 
 @ReactModule(name = GoogleAuthModule.NAME)
 class GoogleAuthModule(reactContext: ReactApplicationContext) :
@@ -864,7 +864,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
     try {
       val parts = idToken.split(".")
       if (parts.size >= 2) {
-        val payload = String(Base64.getUrlDecoder().decode(parts[1]))
+        val payload = String(Base64.decode(parts[1], Base64.NO_WRAP))
         val json = JSONObject(payload)
         val exp = json.optLong("exp", 0)
         if (exp > 0) {
@@ -880,7 +880,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
     try {
       val parts = idToken.split(".")
       if (parts.size >= 2) {
-        val payload = String(Base64.getUrlDecoder().decode(parts[1]))
+        val payload = String(Base64.decode(parts[1], Base64.NO_WRAP))
         val json = JSONObject(payload)
         return json.optString("email", null)
       }

--- a/android/src/main/java/com/googleauth/GoogleAuthModule.kt
+++ b/android/src/main/java/com/googleauth/GoogleAuthModule.kt
@@ -864,7 +864,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
     try {
       val parts = idToken.split(".")
       if (parts.size >= 2) {
-        val payload = String(Base64.decode(parts[1], Base64.NO_WRAP))
+        val payload = String(Base64.decode(parts[1], Base64.URL_SAFE))
         val json = JSONObject(payload)
         val exp = json.optLong("exp", 0)
         if (exp > 0) {
@@ -880,7 +880,7 @@ class GoogleAuthModule(reactContext: ReactApplicationContext) :
     try {
       val parts = idToken.split(".")
       if (parts.size >= 2) {
-        val payload = String(Base64.decode(parts[1], Base64.NO_WRAP))
+        val payload = String(Base64.decode(parts[1], Base64.URL_SAFE))
         val json = JSONObject(payload)
         return json.optString("email", null)
       }


### PR DESCRIPTION
# Summary
This PR replaces the usage of `java.util.Base64` with `android.util.Base64` to ensure full compatibility across all supported Android API levels.

# Problem
* `java.util.Base64` is not available to android SDK < 26, but the minSdk is 24. This results in `java.lang.NoClassDefFoundError: java.util.Base64` that stops google auth process.

# Proposed Solution
* replace the current `java.util.Base64` with the most appropriate `andorid.util.Base64` in order to grant backwards compatibility to < 26 android versions.

# Testing
* Tested on devices/emulators with API < 26 and API ≥ 26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication module optimized for improved platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->