### PR TITLE
fix(ios): use topmost view controller for sign-in presentation

### DIFF
--- a/ios/GoogleAuth.swift
+++ b/ios/GoogleAuth.swift
@@ -435,10 +435,17 @@ class GoogleAuth: NSObject {
     }
     
     private func getPresentingViewController() -> UIViewController? {
-        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = scene.windows.first(where: { $0.isKeyWindow }) {
-            return window.rootViewController
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first(where: { $0.isKeyWindow }),
+              var topViewController = window.rootViewController else {
+            return nil
         }
-        return nil
+        
+        // Traverse the presentation hierarchy to find the topmost presented view controller
+        while let presentedViewController = topViewController.presentedViewController {
+            topViewController = presentedViewController
+        }
+        
+        return topViewController
     }
 }


### PR DESCRIPTION
## Problem

Google Sign-In immediately cancels when triggered from a modal screen (e.g., a login/register modal in React Navigation or Expo Router). The `GIDSignIn` SDK's auth view controller gets dismissed instantly because it's presented on the root view controller while a modal is already covering it.

## Root Cause

`getPresentingViewController()` returns `window.rootViewController`, which may already be presenting a modal. When `GIDSignIn` attempts to present its authentication view controller on a view controller that is already presenting something, iOS dismisses the new presentation immediately, resulting in a `GIDSignInError.canceled` error.

## Fix

Traverse the presentation hierarchy to find the topmost presented view controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on iOS where authentication dialogs could appear in incorrect positions on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->